### PR TITLE
added option to print UUID in uppercase

### DIFF
--- a/generate_uuid.py
+++ b/generate_uuid.py
@@ -2,6 +2,7 @@ import sublime
 import sublime_plugin
 import uuid
 
+
 class GenerateUuidCommand(sublime_plugin.TextCommand):
     """
     Generate a UUID version 4.
@@ -21,6 +22,7 @@ class GenerateUuidCommand(sublime_plugin.TextCommand):
                 value = str(uuid.uuid4())
             self.view.replace(edit, r, value)
 
+
 class GenerateUuidListenerCommand(sublime_plugin.EventListener):
     """
     Expand 'uuid' and 'uuid4' to a random uuid (uuid4) and
@@ -32,9 +34,9 @@ class GenerateUuidListenerCommand(sublime_plugin.EventListener):
     Seealso: https://github.com/SublimeText/GenerateUUID/issues/1
     """
     def on_query_completions(self, view, prefix, locations):
-        if prefix in ('uuid', 'uuid4'): # random
+        if prefix in ('uuid', 'uuid4'):  # random
             val = uuid.uuid4()
-        elif prefix == 'uuid1':         # host and current time
+        elif prefix == 'uuid1':          # host and current time
             val = uuid.uuid1()
         else:
             return []


### PR DESCRIPTION
Hi,
I like my UUIDs to be uppercase, and I figured I'd share my modifications to your plugin (which is really useful, BTW) in case others might like it. All users need to do is put the line `"uuid_uppercase": true` in `Packages/User/Preferences.sublime-settings` to have uppercase UUIDs printed, otherwise it prints lowercase by default. Old users won't see any changes, as the default setting is still lowercase. Please let me know if you have any questions!

Thanks,
Matt Morrison
MattDMo
