### PR TITLE
Rewrite generate_uuid command

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,4 @@
 [
     { "keys": ["ctrl+shift+u"], "command": "generate_uuid" },
-    { "keys": ["ctrl+shift+y"], "command": "generate_short_uuid" }
+    { "keys": ["ctrl+shift+y"], "command": "generate_uuid", "args": { "short": true } }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
 	{ "keys": ["super+shift+u"], "command": "generate_uuid" },
-	{ "keys": ["super+shift+y"], "command": "generate_short_uuid" }
+	{ "keys": ["super+shift+y"], "command": "generate_uuid", "args": { "short": true } }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,4 @@
 [
     { "keys": ["ctrl+shift+u"], "command": "generate_uuid" },
-    { "keys": ["ctrl+shift+y"], "command": "generate_short_uuid" }
+    { "keys": ["ctrl+shift+y"], "command": "generate_uuid", "args": { "short": true } }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -2,5 +2,10 @@
     {
         "caption": "Generate UUID v4",
         "command": "generate_uuid"
+    },
+    {
+        "caption": "Generate single UUID v4",
+        "command": "generate_uuid",
+        "args": { "single": true }
     }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -12,6 +12,21 @@
                     {
                         "caption": "Generate UUID v4",
                         "command": "generate_uuid"
+                    },
+                    {
+                        "caption": "Generate short UUID v4",
+                        "command": "generate_uuid",
+                        "args": { "short": true }
+                    },
+                    {
+                        "caption": "Generate single UUID v4",
+                        "command": "generate_uuid",
+                        "args": { "single": true }
+                    },
+                    {
+                        "caption": "Generate single short UUID v4",
+                        "command": "generate_uuid",
+                        "args": { "short": true, "single": true }
                     }
                 ]
             }

--- a/generate_uuid.py
+++ b/generate_uuid.py
@@ -1,39 +1,38 @@
 import sublime
 import sublime_plugin
 import uuid
-import re
-
 
 class GenerateUuidCommand(sublime_plugin.TextCommand):
     """
     Generate a UUID version 4.
     Plugin logic for the 'generate_uuid' command.
     Searches for "uuid_uppercase" setting in user preferences, capitalizes
-    UUID if true. - author Matt Morrison mattdmo@pigimal.com
-
-    Author: Eric Hamiter
-    Seealso: https://github.com/ehamiter/Sublime-Text-2-Plugins
+    UUID if true.
     """
-    def run(self, edit):
-        for r in self.view.sel():
-            settings = sublime.load_settings('Preferences.sublime-settings')
-            if settings.get('uuid_uppercase'):
-                value = str(uuid.uuid4()).upper()
-            else:
-                value = str(uuid.uuid4())
 
+    def run(self, edit, short = False, single = False):
+        for r, value in zip(self.view.sel(), self.generateUuids(short, single)):
             self.view.replace(edit, r, value)
 
-class GenerateShortUuidCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
-        for r in self.view.sel():
-            settings = sublime.load_settings('Preferences.sublime-settings')
-            if settings.get('uuid_uppercase'):
-                value = str(uuid.uuid4()).upper()
-            else:
-                value = str(uuid.uuid4())
+    def generateUuids(self, short, single):
+        settings = sublime.load_settings('Preferences.sublime-settings')
+        uppercase = settings.get('uuid_uppercase')
 
-            self.view.replace(edit, r, re.sub('-', '', value))
+        if single:
+            value = self.newUuid(uppercase, short)
+            while True:
+                yield value
+        else:
+            while True:
+                yield self.newUuid(uppercase, short)
+
+    def newUuid(self, uppercase, short):
+        value = str(uuid.uuid4())
+        if uppercase:
+            value = value.upper()
+        if short:
+            value = value.replace('-', '')
+        return value
 
 class GenerateUuidListenerCommand(sublime_plugin.EventListener):
     """


### PR DESCRIPTION
Hey,

I was in need to create only a single UUID and place it into multiple cursors at once, so I added that functionality. While I was doing that, I also cleaned up a few things, and improved the code reuse.