### PR TITLE
Changes default keybinding from "super+shift+[uy]"

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
-	{ "keys": ["super+shift+u"], "command": "generate_uuid" },
-	{ "keys": ["super+shift+y"], "command": "generate_uuid", "args": { "short": true } }
+	{ "keys": ["ctrl+shift+u"], "command": "generate_uuid" },
+	{ "keys": ["ctrl+shift+y"], "command": "generate_uuid", "args": { "short": true } }
 ]

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # Generate UUID package for Sublime Text
 
-Helper script to generate a UUID v4. Can be executed via keyboard shortcut `Ctrl+Shift+U` (or `Super+Shift+U` for OSX) and or via the menu item `Tools >> Packages >> Generate UUID v4`.
+Helper script to generate a UUID v4. Can be executed via keyboard shortcut `Ctrl+Shift+U` (Windows, OSX, and Linux) and or via the menu item `Tools >> Packages >> Generate UUID v4`.
 
-`Super+Shift+Y' will generate short version of UUID (for Windows use `Ctrl+Shift+Y`)
+`Ctrl+Shift+Y' will generate short version of UUID
 
 ## Installation
 


### PR DESCRIPTION
in [GenerateUUID/Default (OSX).sublime-keymap](https://github.com/SublimeText/GenerateUUID/blob/master/Default%20%28OSX%29.sublime-keymap), the default "Generate UUID" command is bound to `super+shift+u`, which is the default for `soft_redo`.

Since `soft_redo` is a much more common and useful command, I don't think this plugin should override it.  Keeping keys consistent makes sense, though, so I also changed the "generate short UUID" command to use `ctrl` instead of `super`.  `super+y` is bound to "redo command", so here again it doesn't make sense to have such a close association with that command (even though `super+shift+y` isn't bound to a default command, I think that the `shift` modifier is commonly associated with the "non-shift" command) (plus consistency is a win).
