### PR TITLE
miktemk - firstUuidGroup: generate just the first 8 characters

### DIFF
--- a/generate_uuid.py
+++ b/generate_uuid.py
@@ -10,28 +10,30 @@ class GenerateUuidCommand(sublime_plugin.TextCommand):
     UUID if true.
     """
 
-    def run(self, edit, short = False, single = False):
-        for r, value in zip(self.view.sel(), self.generateUuids(short, single)):
+    def run(self, edit, short = False, single = False, firstUuidGroup = False):
+        for r, value in zip(self.view.sel(), self.generateUuids(short, single, firstUuidGroup)):
             self.view.replace(edit, r, value)
 
-    def generateUuids(self, short, single):
+    def generateUuids(self, short, single, firstUuidGroup):
         settings = sublime.load_settings('Preferences.sublime-settings')
         uppercase = settings.get('uuid_uppercase')
 
         if single:
-            value = self.newUuid(uppercase, short)
+            value = self.newUuid(uppercase, short, firstUuidGroup)
             while True:
                 yield value
         else:
             while True:
-                yield self.newUuid(uppercase, short)
+                yield self.newUuid(uppercase, short, firstUuidGroup)
 
-    def newUuid(self, uppercase, short):
+    def newUuid(self, uppercase, short, firstUuidGroup):
         value = str(uuid.uuid4())
         if uppercase:
             value = value.upper()
         if short:
             value = value.replace('-', '')
+        if firstUuidGroup:
+            value = value[:8]
         return value
 
 class GenerateUuidListenerCommand(sublime_plugin.EventListener):


### PR DESCRIPTION
 - I added the `firstUuidGroup` option to the command. I find this option useful to generate 8-char random UIDs which i use as labels throughout my code. This is similar to [this plugin I wrote for VsCode](https://marketplace.visualstudio.com/items?itemName=miktemk.generate-short-guid)
 - According to [these instructions](https://packagecontrol.io/docs/submitting_a_package) "Try to improve an existing package before adding another", so I decided to add this functionality on top of your existing package.
 - Please let me know if you deem this feature to rather be in its own Sublime package.